### PR TITLE
Fix wrongly named file upload to Sonar

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -62,7 +62,7 @@ jobs:
             -Dsonar.sources=gc_meox_tms/
             -Dsonar.tests=tests/
             -Dsonar.python.coverage.reportPaths=coverage.xml
-            -Dsonar.python.xunit.reportPath=xunit-results.xml
+            -Dsonar.python.xunit.reportPath=xunit-result.xml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
You specify 
`pytest --cov --cov-report term --cov-report xml --junitxml=xunit-result.xml`

but try to upload `xunit-results.xml` < extra `s` to sonarcloud

actions/upload-artifact has the correct path

---
Also maybe consider bumping some of the action versions to newer
`@v2` to `@v4`